### PR TITLE
Upgrade to safecopy-0.9. yesodweb/serversession#5

### DIFF
--- a/serversession-backend-acid-state/serversession-backend-acid-state.cabal
+++ b/serversession-backend-acid-state/serversession-backend-acid-state.cabal
@@ -20,7 +20,7 @@ library
     , acid-state                >= 0.12
     , containers
     , mtl
-    , safecopy                  == 0.8.*
+    , safecopy                  == 0.9.*
     , unordered-containers
 
     , serversession             == 1.0.*

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,8 @@ packages:
   - serversession-frontend-wai
   - serversession-frontend-yesod
 extra-deps:
-  - acid-state-0.13.0
+  - acid-state-0.14.0
   - nonce-1.0.2
   - wai-session-0.3.2
+  - safecopy-0.9.0.1
+  - cereal-0.5.1.0


### PR DESCRIPTION
Passes the test suite with `stack test serversession-backend-acid-state` and the stack.yaml as included in this PR. It also passed with `resolver` set to `nightly-2015-12-30`.
