### PR TITLE
limit the session key as per the the definition comment 'The ID of a …

### DIFF
--- a/serversession-backend-persistent/src/Web/ServerSession/Backend/Persistent/Internal/Impl.hs
+++ b/serversession-backend-persistent/src/Web/ServerSession/Backend/Persistent/Internal/Impl.hs
@@ -150,7 +150,7 @@ instance forall sess. P.PersistFieldSql (Decomposed sess) => P.PersistEntity (Pe
         (P.DBName "key")
         (P.FTTypeCon Nothing "SessionId sess")
         (P.sqlType (Proxy :: Proxy (SessionId sess)))
-        []
+        ["maxlen=30"]
         True
         P.NoReference
   persistFieldDef PersistentSessionAuthId


### PR DESCRIPTION
limit the session key as per the the definition comment 'The ID of a session. Always 18 bytes base64url-encoded as 24 characters.' using 30 characters to be conservative.

This is a response to issue #10 