### PR TITLE
auth id set to default of null to prevent yet another mysql error

### DIFF
--- a/serversession-backend-persistent/src/Web/ServerSession/Backend/Persistent/Internal/Impl.hs
+++ b/serversession-backend-persistent/src/Web/ServerSession/Backend/Persistent/Internal/Impl.hs
@@ -159,7 +159,7 @@ instance forall sess. P.PersistFieldSql (Decomposed sess) => P.PersistEntity (Pe
         (P.DBName "auth_id")
         (P.FTTypeCon Nothing "ByteStringJ")
         (P.sqlType (Proxy :: Proxy ByteStringJ))
-        ["Maybe"]
+        ["Maybe", "default=NULL"]
         True
         P.NoReference
   persistFieldDef PersistentSessionSession


### PR DESCRIPTION
with the auth_id as a maybe mysql complains that you aren't able to set a default value on a blob, for some reason adding default=NULL it shuts up.