### PR TITLE
Bump hedis constraint to < 0.13

### DIFF
--- a/serversession-backend-redis/serversession-backend-redis.cabal
+++ b/serversession-backend-redis/serversession-backend-redis.cabal
@@ -27,7 +27,7 @@ library
   build-depends:
       base                      == 4.*
     , bytestring
-    , hedis                     < 0.11
+    , hedis                     < 0.13
     , path-pieces
     , tagged                    >= 0.7
     , text


### PR DESCRIPTION
The newer hedis versions work fine. This will also fix compilation in nixpkgs (I'm not sure whether this would also fix it on stackage too).