### PR TITLE
fixed: limit CI to master for push triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   core-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Duplicate checks on "push" and "pull_request" simultaneous event - Code to Cloud / GitHub Actions - GitHub Community](https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012)