### PR TITLE
chore: re-release serversession-backend-persistent-2.0.3 

### DIFF
--- a/serversession-backend-persistent/changelog.md
+++ b/serversession-backend-persistent/changelog.md
@@ -1,3 +1,7 @@
+# 2.0.2
+
+I allow `persistent >= 2.13.0.0 && < 2.15.0.0`.
+
 # 2.0.1
 
 I limit `persistent` version to `2.13.*`

--- a/serversession-backend-persistent/changelog.md
+++ b/serversession-backend-persistent/changelog.md
@@ -1,3 +1,7 @@
+# 2.0.3
+
+Synchronize deployed version with GitHub commit.
+
 # 2.0.2
 
 I allow `persistent >= 2.13.0.0 && < 2.15.0.0`.

--- a/serversession-backend-persistent/serversession-backend-persistent.cabal
+++ b/serversession-backend-persistent/serversession-backend-persistent.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            serversession-backend-persistent
-version:         2.0.2
+version:         2.0.3
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>


### PR DESCRIPTION
Why
===

Synchronize Git commit state with Hackage deploy state, since there was a modified commit after the release version modification before and deployed.